### PR TITLE
Add new `emodnet_thematic_lot` column to `emodnet_wfs()` and explain what are thematic lots

### DIFF
--- a/R/emodnet_wfs.R
+++ b/R/emodnet_wfs.R
@@ -9,6 +9,13 @@
 #'
 #' @title Which data sources (services) are available?
 #'
+#' @format ## `emodnet_wfs`
+#' \describe{
+#'   \item{emodnet_thematic_lot}{EMODnet disciplinary themes - bathymetry, biology, chemistry, geology, human activities, physics and seabed habitats}
+#'   \item{service_name}{Name of the specific service. Use in [emodnet_init_wfs_client].}
+#'   \item{service_url}{[Web Feature Service (WFS)](https://www.ogc.org/publications/standard/wfs/) URL endpoint for accessing the service.}
+#' }
+#'
 #' @return Tibble of available EMODnet Web Feature Services
 #'
 #' @examplesIf identical(Sys.getenv("IN_PKGDOWN"), "true") || interactive()

--- a/R/emodnet_wfs.R
+++ b/R/emodnet_wfs.R
@@ -11,9 +11,13 @@
 #'
 #' @format ## `emodnet_wfs`
 #' \describe{
-#'   \item{emodnet_thematic_lot}{EMODnet disciplinary themes - bathymetry, biology, chemistry, geology, human activities, physics and seabed habitats}
-#'   \item{service_name}{Name of the specific service. Use in [emodnet_init_wfs_client].}
-#'   \item{service_url}{[Web Feature Service (WFS)](https://www.ogc.org/publications/standard/wfs/) URL endpoint for accessing the service.}
+#'   \item{emodnet_thematic_lot}{EMODnet disciplinary themes - bathymetry,
+#'   biology, chemistry, geology, human activities, physics and seabed habitats}
+#'   \item{service_name}{Name of the specific service.
+#'   Use in [emodnet_init_wfs_client].}
+#'   \item{service_url}{
+#'   [Web Feature Service (WFS)](https://www.ogc.org/publications/standard/wfs/)
+#'    URL endpoint for accessing the service.}
 #' }
 #'
 #' @return Tibble of available EMODnet Web Feature Services

--- a/README.Rmd
+++ b/README.Rmd
@@ -61,15 +61,16 @@ In the documentation we assume a basic familiarity with spatial data: knowing ab
 
 ## Available data sources (services)
 
-All available data sources, called services, are contained in the [tibble](https://tibble.tidyverse.org/) returned by `emodnet_wfs()`.
-
+All available data sources, called services, are contained in the [tibble](https://tibble.tidyverse.org/) returned by `emodnet_wfs()`. 
 ```{r, echo=TRUE}
 library(emodnet.wfs)
 services <- emodnet_wfs()
 class(services)
 names(services)
-services$service_name
+services[, c("emodnet_thematic_lot", "service_name")]
 ```
+
+EMODnet data covers several disciplines organized in 7 thematic lots: bathymetry, biology, chemistry, geology, human activities, physics, seabed habitats. Some thematic lots organize their data in more than one data source or service.
 
 To explore available services you can use `View()` or your usual way to explore `data.frames`.
 

--- a/README.md
+++ b/README.md
@@ -83,26 +83,34 @@ services <- emodnet_wfs()
 class(services)
 #> [1] "tbl_df"     "tbl"        "data.frame"
 names(services)
-#> [1] "service_name" "service_url"
-services$service_name
-#>  [1] "bathymetry"                                                     
-#>  [2] "biology"                                                        
-#>  [3] "biology_occurrence_data"                                        
-#>  [4] "chemistry_cdi_data_discovery_and_access_service"                
-#>  [5] "chemistry_cdi_distribution_observations_per_category_and_region"
-#>  [6] "chemistry_contaminants"                                         
-#>  [7] "chemistry_marine_litter"                                        
-#>  [8] "geology_coastal_behavior"                                       
-#>  [9] "geology_events_and_probabilities"                               
-#> [10] "geology_marine_minerals"                                        
-#> [11] "geology_sea_floor_bedrock"                                      
-#> [12] "geology_seabed_substrate_maps"                                  
-#> [13] "geology_submerged_landscapes"                                   
-#> [14] "human_activities"                                               
-#> [15] "physics"                                                        
-#> [16] "seabed_habitats_general_datasets_and_products"                  
-#> [17] "seabed_habitats_individual_habitat_map_and_model_datasets"
+#> [1] "emodnet_thematic_lot" "service_name"         "service_url"
+services[, c("emodnet_thematic_lot", "service_name")]
+#> # A tibble: 17 × 2
+#>    emodnet_thematic_lot     service_name                                        
+#>    <chr>                    <chr>                                               
+#>  1 EMODnet Bathymetry       bathymetry                                          
+#>  2 EMODnet Biology          biology                                             
+#>  3 EMODnet Biology          biology_occurrence_data                             
+#>  4 EMODnet Chemistry        chemistry_cdi_data_discovery_and_access_service     
+#>  5 EMODnet Chemistry        chemistry_cdi_distribution_observations_per_categor…
+#>  6 EMODnet Chemistry        chemistry_contaminants                              
+#>  7 EMODnet Chemistry        chemistry_marine_litter                             
+#>  8 EMODnet Geology          geology_coastal_behavior                            
+#>  9 EMODnet Geology          geology_events_and_probabilities                    
+#> 10 EMODnet Geology          geology_marine_minerals                             
+#> 11 EMODnet Geology          geology_sea_floor_bedrock                           
+#> 12 EMODnet Geology          geology_seabed_substrate_maps                       
+#> 13 EMODnet Geology          geology_submerged_landscapes                        
+#> 14 EMODnet Human Activities human_activities                                    
+#> 15 EMODnet Physics          physics                                             
+#> 16 EMODnet Seabed Habitats  seabed_habitats_general_datasets_and_products       
+#> 17 EMODnet Seabed Habitats  seabed_habitats_individual_habitat_map_and_model_da…
 ```
+
+EMODnet data covers several disciplines organized in 7 thematic lots:
+bathymetry, biology, chemistry, geology, human activities, physics,
+seabed habitats. Some thematic lots organize their data in more than one
+data source or service.
 
 To explore available services you can use `View()` or your usual way to
 explore `data.frames`.

--- a/inst/services.csv
+++ b/inst/services.csv
@@ -1,18 +1,18 @@
-service_name,service_url
-bathymetry,https://ows.emodnet-bathymetry.eu/wfs
-biology,https://geo.vliz.be/geoserver/Emodnetbio/wfs
-biology_occurrence_data,https://geo.vliz.be/geoserver/Dataportal/wfs
-chemistry_cdi_data_discovery_and_access_service,https://geo-service.maris.nl/emodnet_chemistry/wfs
-chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs
-chemistry_contaminants,https://geoserver.hcmr.gr/geoserver/EMODNET_SHARED/wfs
-chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2
-geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs
-geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs
-geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs
-geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs
-geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs
-geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs
-human_activities,https://ows.emodnet-humanactivities.eu/wfs
-physics,https://prod-geoserver.emodnet-physics.eu/geoserver/ows
-seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs
-seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs
+emodnet_thematic_lot,service_name,service_url
+EMODnet Bathymetry,bathymetry,https://ows.emodnet-bathymetry.eu/wfs
+EMODnet Biology,biology,https://geo.vliz.be/geoserver/Emodnetbio/wfs
+EMODnet Biology,biology_occurrence_data,https://geo.vliz.be/geoserver/Dataportal/wfs
+EMODnet Chemistry,chemistry_cdi_data_discovery_and_access_service,https://geo-service.maris.nl/emodnet_chemistry/wfs
+EMODnet Chemistry,chemistry_cdi_distribution_observations_per_category_and_region,https://geo-service.maris.nl/emodnet_chemistry_p36/wfs
+EMODnet Chemistry,chemistry_contaminants,https://geoserver.hcmr.gr/geoserver/EMODNET_SHARED/wfs
+EMODnet Chemistry,chemistry_marine_litter,https://www.ifremer.fr/services/wfs/emodnet_chemistry2
+EMODnet Geology,geology_coastal_behavior,https://drive.emodnet-geology.eu/geoserver/tno/wfs
+EMODnet Geology,geology_events_and_probabilities,https://drive.emodnet-geology.eu/geoserver/ispra/wfs
+EMODnet Geology,geology_marine_minerals,https://drive.emodnet-geology.eu/geoserver/gsi/wfs
+EMODnet Geology,geology_sea_floor_bedrock,https://drive.emodnet-geology.eu/geoserver/bgr/wfs
+EMODnet Geology,geology_seabed_substrate_maps,https://drive.emodnet-geology.eu/geoserver/gtk/wfs
+EMODnet Geology,geology_submerged_landscapes,https://drive.emodnet-geology.eu/geoserver/bgs/wfs
+EMODnet Human Activities,human_activities,https://ows.emodnet-humanactivities.eu/wfs
+EMODnet Physics,physics,https://prod-geoserver.emodnet-physics.eu/geoserver/ows
+EMODnet Seabed Habitats,seabed_habitats_general_datasets_and_products,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs
+EMODnet Seabed Habitats,seabed_habitats_individual_habitat_map_and_model_datasets,https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open_maplibrary/wfs

--- a/man/emodnet_wfs.Rd
+++ b/man/emodnet_wfs.Rd
@@ -7,9 +7,13 @@
 \subsection{\code{emodnet_wfs}}{
 
 \describe{
-\item{emodnet_thematic_lot}{EMODnet disciplinary themes - bathymetry, biology, chemistry, geology, human activities, physics and seabed habitats}
-\item{service_name}{Name of the specific service. Use in \link{emodnet_init_wfs_client}.}
-\item{service_url}{\href{https://www.ogc.org/publications/standard/wfs/}{Web Feature Service (WFS)} URL endpoint for accessing the service.}
+\item{emodnet_thematic_lot}{EMODnet disciplinary themes - bathymetry,
+biology, chemistry, geology, human activities, physics and seabed habitats}
+\item{service_name}{Name of the specific service.
+Use in \link{emodnet_init_wfs_client}.}
+\item{service_url}{
+\href{https://www.ogc.org/publications/standard/wfs/}{Web Feature Service (WFS)}
+URL endpoint for accessing the service.}
 }
 }
 }

--- a/man/emodnet_wfs.Rd
+++ b/man/emodnet_wfs.Rd
@@ -3,6 +3,16 @@
 \name{emodnet_wfs}
 \alias{emodnet_wfs}
 \title{Which data sources (services) are available?}
+\format{
+\subsection{\code{emodnet_wfs}}{
+
+\describe{
+\item{emodnet_thematic_lot}{EMODnet disciplinary themes - bathymetry, biology, chemistry, geology, human activities, physics and seabed habitats}
+\item{service_name}{Name of the specific service. Use in \link{emodnet_init_wfs_client}.}
+\item{service_url}{\href{https://www.ogc.org/publications/standard/wfs/}{Web Feature Service (WFS)} URL endpoint for accessing the service.}
+}
+}
+}
 \usage{
 emodnet_wfs()
 }

--- a/vignettes/emodnet.wfs.Rmd
+++ b/vignettes/emodnet.wfs.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Accessing and mapping EMODnet data"
-output: rmarkdown::html_vignette
+output: github_document
 df_print: "tibble"
 vignette: >
   %\VignetteIndexEntry{API details}
@@ -49,37 +49,42 @@ For that, we can check the services available with the `emodnet_wfs()` function.
 library(emodnet.wfs)
 library(mapview)
 library(sf)
-#> Error in value[[3L]](cond): Package 'sf' version 1.0.18 cannot be unloaded:
-#>  Error in unloadNamespace(package) : namespace 'sf' is imported by 'ows4R', 'mapview', 'leafem', 'leafpop' so cannot be unloaded
 
 services <- emodnet_wfs()
-services$service_name
-#>  [1] "bathymetry"                                                     
-#>  [2] "biology"                                                        
-#>  [3] "biology_occurrence_data"                                        
-#>  [4] "chemistry_cdi_data_discovery_and_access_service"                
-#>  [5] "chemistry_cdi_distribution_observations_per_category_and_region"
-#>  [6] "chemistry_contaminants"                                         
-#>  [7] "chemistry_marine_litter"                                        
-#>  [8] "geology_coastal_behavior"                                       
-#>  [9] "geology_events_and_probabilities"                               
-#> [10] "geology_marine_minerals"                                        
-#> [11] "geology_sea_floor_bedrock"                                      
-#> [12] "geology_seabed_substrate_maps"                                  
-#> [13] "geology_submerged_landscapes"                                   
-#> [14] "human_activities"                                               
-#> [15] "physics"                                                        
-#> [16] "seabed_habitats_general_datasets_and_products"                  
-#> [17] "seabed_habitats_individual_habitat_map_and_model_datasets"
+class(services)
+#> [1] "tbl_df"     "tbl"        "data.frame"
+names(services)
+#> [1] "emodnet_thematic_lot" "service_name"         "service_url"
+services[, c("emodnet_thematic_lot", "service_name")]
+#> # A tibble: 17 × 2
+#>    emodnet_thematic_lot     service_name                                        
+#>    <chr>                    <chr>                                               
+#>  1 EMODnet Bathymetry       bathymetry                                          
+#>  2 EMODnet Biology          biology                                             
+#>  3 EMODnet Biology          biology_occurrence_data                             
+#>  4 EMODnet Chemistry        chemistry_cdi_data_discovery_and_access_service     
+#>  5 EMODnet Chemistry        chemistry_cdi_distribution_observations_per_categor…
+#>  6 EMODnet Chemistry        chemistry_contaminants                              
+#>  7 EMODnet Chemistry        chemistry_marine_litter                             
+#>  8 EMODnet Geology          geology_coastal_behavior                            
+#>  9 EMODnet Geology          geology_events_and_probabilities                    
+#> 10 EMODnet Geology          geology_marine_minerals                             
+#> 11 EMODnet Geology          geology_sea_floor_bedrock                           
+#> 12 EMODnet Geology          geology_seabed_substrate_maps                       
+#> 13 EMODnet Geology          geology_submerged_landscapes                        
+#> 14 EMODnet Human Activities human_activities                                    
+#> 15 EMODnet Physics          physics                                             
+#> 16 EMODnet Seabed Habitats  seabed_habitats_general_datasets_and_products       
+#> 17 EMODnet Seabed Habitats  seabed_habitats_individual_habitat_map_and_model_da…
 ```
 
-
-
-The column `service_name` shows services available, while  `service_url` has the corresponding base url to perform a WFS request. The Seabed portal should have the data we are looking for. A WFS client can be created by passing the corresponding `service_name` to the function `emodnet_init_wfs_client()`. The layers available to this WFS client are consulted with `emodnet_get_wfs_info()`.
+EMODnet data covers several disciplines organized in 7 thematic lots: bathymetry, biology, chemistry, geology, human activities, physics, seabed habitats. Some thematic lots organize their data in more than one data source or service. The column `service_name` shows services available, while  `service_url` has the corresponding base url to perform a WFS request. The Seabed portal should have the data we are looking for. A WFS client can be created by passing the corresponding `service_name` to the function `emodnet_init_wfs_client()`. The layers available to this WFS client are consulted with `emodnet_get_wfs_info()`.
 
 
 ``` r
 seabed_wfs_client <- emodnet_init_wfs_client(service = "seabed_habitats_general_datasets_and_products")
+#> Loading ISO 19139 XML schemas...
+#> Loading ISO 19115 codelists...
 #> ✔ WFS client created successfully
 #> ℹ Service: "https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs"
 #> ℹ Version: "2.0.0"
@@ -87,18 +92,18 @@ seabed_wfs_client <- emodnet_init_wfs_client(service = "seabed_habitats_general_
 emodnet_get_wfs_info(wfs = seabed_wfs_client)
 #> # A tibble: 72 × 9
 #> # Rowwise: 
-#>    data_source service_name          service_url layer_name title abstract class format
-#>    <chr>       <chr>                 <chr>       <chr>      <chr> <chr>    <chr> <chr> 
-#>  1 emodnet_wfs seabed_habitats_gene… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  2 emodnet_wfs seabed_habitats_gene… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  3 emodnet_wfs seabed_habitats_gene… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  4 emodnet_wfs seabed_habitats_gene… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  5 emodnet_wfs seabed_habitats_gene… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  6 emodnet_wfs seabed_habitats_gene… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  7 emodnet_wfs seabed_habitats_gene… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  8 emodnet_wfs seabed_habitats_gene… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  9 emodnet_wfs seabed_habitats_gene… https://ow… carib_eus… 2023… "Output… WFSF… sf    
-#> 10 emodnet_wfs seabed_habitats_gene… https://ow… biogenic_… Biog… "This l… WFSF… sf    
+#>    data_source service_name   service_url layer_name title abstract class format
+#>    <chr>       <chr>          <chr>       <chr>      <chr> <chr>    <chr> <chr> 
+#>  1 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  2 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  3 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  4 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  5 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  6 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  7 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  8 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  9 emodnet_wfs seabed_habita… https://ow… carib_eus… 2023… "Output… WFSF… sf    
+#> 10 emodnet_wfs seabed_habita… https://ow… biogenic_… Biog… "This l… WFSF… sf    
 #> # ℹ 62 more rows
 #> # ℹ 1 more variable: layer_namespace <chr>
 ```
@@ -117,11 +122,11 @@ emodnet_get_layer_info(
 )
 #> # A tibble: 3 × 9
 #> # Rowwise: 
-#>   data_source service_name           service_url layer_name title abstract class format
-#>   <chr>       <chr>                  <chr>       <chr>      <chr> <chr>    <chr> <chr> 
-#> 1 emodnet_wfs https://ows.emodnet-s… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
-#> 2 emodnet_wfs https://ows.emodnet-s… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
-#> 3 emodnet_wfs https://ows.emodnet-s… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
+#>   data_source service_name    service_url layer_name title abstract class format
+#>   <chr>       <chr>           <chr>       <chr>      <chr> <chr>    <chr> <chr> 
+#> 1 emodnet_wfs https://ows.em… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
+#> 2 emodnet_wfs https://ows.em… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
+#> 3 emodnet_wfs https://ows.em… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
 #> # ℹ 1 more variable: layer_namespace <chr>
 ```
 
@@ -137,9 +142,6 @@ habitats_directive_layers <- emodnet_get_layers(
   simplify = TRUE,
   outputFormat = "application/json"
 )
-#> Start tag expected, '<' not found
-#> Start tag expected, '<' not found
-#> Start tag expected, '<' not found
 
 habitats_directive_layers
 #> Simple feature collection with 221 features and 8 fields
@@ -202,12 +204,8 @@ Run the following code to have a quick look at the layers geometries.
 
 ``` r
 mapview(habitats_directive_layers, zcol = "habitat_description", burst = TRUE)
+#> Error in loadNamespace(name): there is no package called 'webshot'
 ```
-
-<div class="figure">
-<img src="emodnet.wfs-unnamed-chunk-6-1.png" alt="Interactive map of layers in the habitat directive"  />
-<p class="caption">plot of chunk unnamed-chunk-6</p>
-</div>
 
 EMODnet provides also physics, chemistry, biological or bathymetry data. Explore all the layers available with:
 
@@ -216,18 +214,18 @@ EMODnet provides also physics, chemistry, biological or bathymetry data. Explore
 emodnet_get_all_wfs_info()
 #> # A tibble: 1,713 × 9
 #> # Rowwise: 
-#>    data_source service_name service_url          layer_name title abstract class format
-#>    <chr>       <chr>        <chr>                <chr>      <chr> <chr>    <chr> <chr> 
-#>  1 emodnet_wfs bathymetry   https://ows.emodnet… download_… Bath… "Downlo… WFSF… sf    
-#>  2 emodnet_wfs bathymetry   https://ows.emodnet… contours   Dept… "Genera… WFSF… sf    
-#>  3 emodnet_wfs bathymetry   https://ows.emodnet… hr_bathym… High… "Layer … WFSF… sf    
-#>  4 emodnet_wfs bathymetry   https://ows.emodnet… quality_i… Qual… "Repres… WFSF… sf    
-#>  5 emodnet_wfs bathymetry   https://ows.emodnet… sea_names  Sea … "Mainta… WFSF… sf    
-#>  6 emodnet_wfs bathymetry   https://ows.emodnet… source_re… Sour… "Covera… WFSF… sf    
-#>  7 emodnet_wfs bathymetry   https://ows.emodnet… undersea_… unde… ""       WFSF… sf    
-#>  8 emodnet_wfs biology      https://geo.vliz.be… mediseh_c… EMOD… "Coral … WFSF… sf    
-#>  9 emodnet_wfs biology      https://geo.vliz.be… mediseh_c… EMOD… "Coral … WFSF… sf    
-#> 10 emodnet_wfs biology      https://geo.vliz.be… mediseh_c… EMOD… "Cymodo… WFSF… sf    
+#>    data_source service_name service_url   layer_name title abstract class format
+#>    <chr>       <chr>        <chr>         <chr>      <chr> <chr>    <chr> <chr> 
+#>  1 emodnet_wfs bathymetry   https://ows.… download_… Bath… "Downlo… WFSF… sf    
+#>  2 emodnet_wfs bathymetry   https://ows.… contours   Dept… "Genera… WFSF… sf    
+#>  3 emodnet_wfs bathymetry   https://ows.… hr_bathym… High… "Layer … WFSF… sf    
+#>  4 emodnet_wfs bathymetry   https://ows.… quality_i… Qual… "Repres… WFSF… sf    
+#>  5 emodnet_wfs bathymetry   https://ows.… sea_names  Sea … "Mainta… WFSF… sf    
+#>  6 emodnet_wfs bathymetry   https://ows.… source_re… Sour… "Covera… WFSF… sf    
+#>  7 emodnet_wfs bathymetry   https://ows.… undersea_… unde… ""       WFSF… sf    
+#>  8 emodnet_wfs biology      https://geo.… mediseh_c… EMOD… "Coral … WFSF… sf    
+#>  9 emodnet_wfs biology      https://geo.… mediseh_c… EMOD… "Coral … WFSF… sf    
+#> 10 emodnet_wfs biology      https://geo.… mediseh_c… EMOD… "Cymodo… WFSF… sf    
 #> # ℹ 1,703 more rows
 #> # ℹ 1 more variable: layer_namespace <chr>
 ```
@@ -257,14 +255,15 @@ To cite emodnet.wfs, please use the output from `citation(package = "emodnet.wfs
 citation(package = "emodnet.wfs")
 #> To cite package 'emodnet.wfs' in publications use:
 #> 
-#>   Krystalli A, Fernández-Bejarano S, Salmon M (????). _emodnet.wfs: Access
-#>   EMODnet Web Feature Service data through R_. doi:10.14284/679
-#>   <https://doi.org/10.14284/679>, R package version 2.0.2.9000. Integrated
-#>   data products created under the European Marine Observation Data Network
-#>   (EMODnet) Biology project (EASME/EMFF/2017/1.3.1.2/02/SI2.789013), funded
-#>   by the by the European Union under Regulation (EU) No 508/2014 of the
-#>   European Parliament and of the Council of 15 May 2014 on the European
-#>   Maritime and Fisheries Fund, <https://github.com/EMODnet/emodnet.wfs>.
+#>   Krystalli A, Fernández-Bejarano S, Salmon M (????). _emodnet.wfs:
+#>   Access EMODnet Web Feature Service data through R_. doi:10.14284/679
+#>   <https://doi.org/10.14284/679>, R package version 2.0.2.9000.
+#>   Integrated data products created under the European Marine
+#>   Observation Data Network (EMODnet) Biology project
+#>   (EASME/EMFF/2017/1.3.1.2/02/SI2.789013), funded by the by the
+#>   European Union under Regulation (EU) No 508/2014 of the European
+#>   Parliament and of the Council of 15 May 2014 on the European Maritime
+#>   and Fisheries Fund, <https://github.com/EMODnet/emodnet.wfs>.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 

--- a/vignettes/emodnet.wfs.Rmd
+++ b/vignettes/emodnet.wfs.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Accessing and mapping EMODnet data"
 output: rmarkdown::html_vignette
-df_print: "tibble"
+df_print: "kable"
 vignette: >
   %\VignetteIndexEntry{API details}
   %\VignetteEngine{knitr::rmarkdown}
@@ -57,25 +57,25 @@ names(services)
 #> [1] "emodnet_thematic_lot" "service_name"         "service_url"
 services[, c("emodnet_thematic_lot", "service_name")]
 #> # A tibble: 17 × 2
-#>    emodnet_thematic_lot     service_name                                        
-#>    <chr>                    <chr>                                               
-#>  1 EMODnet Bathymetry       bathymetry                                          
-#>  2 EMODnet Biology          biology                                             
-#>  3 EMODnet Biology          biology_occurrence_data                             
-#>  4 EMODnet Chemistry        chemistry_cdi_data_discovery_and_access_service     
-#>  5 EMODnet Chemistry        chemistry_cdi_distribution_observations_per_categor…
-#>  6 EMODnet Chemistry        chemistry_contaminants                              
-#>  7 EMODnet Chemistry        chemistry_marine_litter                             
-#>  8 EMODnet Geology          geology_coastal_behavior                            
-#>  9 EMODnet Geology          geology_events_and_probabilities                    
-#> 10 EMODnet Geology          geology_marine_minerals                             
-#> 11 EMODnet Geology          geology_sea_floor_bedrock                           
-#> 12 EMODnet Geology          geology_seabed_substrate_maps                       
-#> 13 EMODnet Geology          geology_submerged_landscapes                        
-#> 14 EMODnet Human Activities human_activities                                    
-#> 15 EMODnet Physics          physics                                             
-#> 16 EMODnet Seabed Habitats  seabed_habitats_general_datasets_and_products       
-#> 17 EMODnet Seabed Habitats  seabed_habitats_individual_habitat_map_and_model_da…
+#>    emodnet_thematic_lot     service_name                                                
+#>    <chr>                    <chr>                                                       
+#>  1 EMODnet Bathymetry       bathymetry                                                  
+#>  2 EMODnet Biology          biology                                                     
+#>  3 EMODnet Biology          biology_occurrence_data                                     
+#>  4 EMODnet Chemistry        chemistry_cdi_data_discovery_and_access_service             
+#>  5 EMODnet Chemistry        chemistry_cdi_distribution_observations_per_category_and_re…
+#>  6 EMODnet Chemistry        chemistry_contaminants                                      
+#>  7 EMODnet Chemistry        chemistry_marine_litter                                     
+#>  8 EMODnet Geology          geology_coastal_behavior                                    
+#>  9 EMODnet Geology          geology_events_and_probabilities                            
+#> 10 EMODnet Geology          geology_marine_minerals                                     
+#> 11 EMODnet Geology          geology_sea_floor_bedrock                                   
+#> 12 EMODnet Geology          geology_seabed_substrate_maps                               
+#> 13 EMODnet Geology          geology_submerged_landscapes                                
+#> 14 EMODnet Human Activities human_activities                                            
+#> 15 EMODnet Physics          physics                                                     
+#> 16 EMODnet Seabed Habitats  seabed_habitats_general_datasets_and_products               
+#> 17 EMODnet Seabed Habitats  seabed_habitats_individual_habitat_map_and_model_datasets
 ```
 
 EMODnet data covers several disciplines organized in 7 thematic lots: bathymetry, biology, chemistry, geology, human activities, physics, seabed habitats. Some thematic lots organize their data in more than one data source or service. The column `service_name` shows services available, while  `service_url` has the corresponding base url to perform a WFS request. The Seabed portal should have the data we are looking for. A WFS client can be created by passing the corresponding `service_name` to the function `emodnet_init_wfs_client()`. The layers available to this WFS client are consulted with `emodnet_get_wfs_info()`.
@@ -83,8 +83,6 @@ EMODnet data covers several disciplines organized in 7 thematic lots: bathymetry
 
 ``` r
 seabed_wfs_client <- emodnet_init_wfs_client(service = "seabed_habitats_general_datasets_and_products")
-#> Loading ISO 19139 XML schemas...
-#> Loading ISO 19115 codelists...
 #> ✔ WFS client created successfully
 #> ℹ Service: "https://ows.emodnet-seabedhabitats.eu/geoserver/emodnet_open/wfs"
 #> ℹ Version: "2.0.0"
@@ -92,18 +90,18 @@ seabed_wfs_client <- emodnet_init_wfs_client(service = "seabed_habitats_general_
 emodnet_get_wfs_info(wfs = seabed_wfs_client)
 #> # A tibble: 72 × 9
 #> # Rowwise: 
-#>    data_source service_name   service_url layer_name title abstract class format
-#>    <chr>       <chr>          <chr>       <chr>      <chr> <chr>    <chr> <chr> 
-#>  1 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  2 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  3 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  4 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  5 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  6 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  7 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  8 emodnet_wfs seabed_habita… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
-#>  9 emodnet_wfs seabed_habita… https://ow… carib_eus… 2023… "Output… WFSF… sf    
-#> 10 emodnet_wfs seabed_habita… https://ow… biogenic_… Biog… "This l… WFSF… sf    
+#>    data_source service_name           service_url layer_name title abstract class format
+#>    <chr>       <chr>                  <chr>       <chr>      <chr> <chr>    <chr> <chr> 
+#>  1 emodnet_wfs seabed_habitats_gener… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  2 emodnet_wfs seabed_habitats_gener… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  3 emodnet_wfs seabed_habitats_gener… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  4 emodnet_wfs seabed_habitats_gener… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  5 emodnet_wfs seabed_habitats_gener… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  6 emodnet_wfs seabed_habitats_gener… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  7 emodnet_wfs seabed_habitats_gener… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  8 emodnet_wfs seabed_habitats_gener… https://ow… art17_hab… 2013… "Gridde… WFSF… sf    
+#>  9 emodnet_wfs seabed_habitats_gener… https://ow… carib_eus… 2023… "Output… WFSF… sf    
+#> 10 emodnet_wfs seabed_habitats_gener… https://ow… biogenic_… Biog… "This l… WFSF… sf    
 #> # ℹ 62 more rows
 #> # ℹ 1 more variable: layer_namespace <chr>
 ```
@@ -122,11 +120,11 @@ emodnet_get_layer_info(
 )
 #> # A tibble: 3 × 9
 #> # Rowwise: 
-#>   data_source service_name    service_url layer_name title abstract class format
-#>   <chr>       <chr>           <chr>       <chr>      <chr> <chr>    <chr> <chr> 
-#> 1 emodnet_wfs https://ows.em… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
-#> 2 emodnet_wfs https://ows.em… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
-#> 3 emodnet_wfs https://ows.em… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
+#>   data_source service_name            service_url layer_name title abstract class format
+#>   <chr>       <chr>                   <chr>       <chr>      <chr> <chr>    <chr> <chr> 
+#> 1 emodnet_wfs https://ows.emodnet-se… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
+#> 2 emodnet_wfs https://ows.emodnet-se… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
+#> 3 emodnet_wfs https://ows.emodnet-se… seabed_hab… art17_hab… 2013… "Gridde… WFSF… sf    
 #> # ℹ 1 more variable: layer_namespace <chr>
 ```
 
@@ -142,6 +140,9 @@ habitats_directive_layers <- emodnet_get_layers(
   simplify = TRUE,
   outputFormat = "application/json"
 )
+#> Start tag expected, '<' not found
+#> Start tag expected, '<' not found
+#> Start tag expected, '<' not found
 
 habitats_directive_layers
 #> Simple feature collection with 221 features and 8 fields
@@ -204,8 +205,12 @@ Run the following code to have a quick look at the layers geometries.
 
 ``` r
 mapview(habitats_directive_layers, zcol = "habitat_description", burst = TRUE)
-#> Error in loadNamespace(name): there is no package called 'webshot'
 ```
+
+<div class="figure">
+<img src="emodnet.wfs-unnamed-chunk-6-1.png" alt="Interactive map of layers in the habitat directive"  />
+<p class="caption">plot of chunk unnamed-chunk-6</p>
+</div>
 
 EMODnet provides also physics, chemistry, biological or bathymetry data. Explore all the layers available with:
 
@@ -214,18 +219,18 @@ EMODnet provides also physics, chemistry, biological or bathymetry data. Explore
 emodnet_get_all_wfs_info()
 #> # A tibble: 1,713 × 9
 #> # Rowwise: 
-#>    data_source service_name service_url   layer_name title abstract class format
-#>    <chr>       <chr>        <chr>         <chr>      <chr> <chr>    <chr> <chr> 
-#>  1 emodnet_wfs bathymetry   https://ows.… download_… Bath… "Downlo… WFSF… sf    
-#>  2 emodnet_wfs bathymetry   https://ows.… contours   Dept… "Genera… WFSF… sf    
-#>  3 emodnet_wfs bathymetry   https://ows.… hr_bathym… High… "Layer … WFSF… sf    
-#>  4 emodnet_wfs bathymetry   https://ows.… quality_i… Qual… "Repres… WFSF… sf    
-#>  5 emodnet_wfs bathymetry   https://ows.… sea_names  Sea … "Mainta… WFSF… sf    
-#>  6 emodnet_wfs bathymetry   https://ows.… source_re… Sour… "Covera… WFSF… sf    
-#>  7 emodnet_wfs bathymetry   https://ows.… undersea_… unde… ""       WFSF… sf    
-#>  8 emodnet_wfs biology      https://geo.… mediseh_c… EMOD… "Coral … WFSF… sf    
-#>  9 emodnet_wfs biology      https://geo.… mediseh_c… EMOD… "Coral … WFSF… sf    
-#> 10 emodnet_wfs biology      https://geo.… mediseh_c… EMOD… "Cymodo… WFSF… sf    
+#>    data_source service_name service_url           layer_name title abstract class format
+#>    <chr>       <chr>        <chr>                 <chr>      <chr> <chr>    <chr> <chr> 
+#>  1 emodnet_wfs bathymetry   https://ows.emodnet-… download_… Bath… "Downlo… WFSF… sf    
+#>  2 emodnet_wfs bathymetry   https://ows.emodnet-… contours   Dept… "Genera… WFSF… sf    
+#>  3 emodnet_wfs bathymetry   https://ows.emodnet-… hr_bathym… High… "Layer … WFSF… sf    
+#>  4 emodnet_wfs bathymetry   https://ows.emodnet-… quality_i… Qual… "Repres… WFSF… sf    
+#>  5 emodnet_wfs bathymetry   https://ows.emodnet-… sea_names  Sea … "Mainta… WFSF… sf    
+#>  6 emodnet_wfs bathymetry   https://ows.emodnet-… source_re… Sour… "Covera… WFSF… sf    
+#>  7 emodnet_wfs bathymetry   https://ows.emodnet-… undersea_… unde… ""       WFSF… sf    
+#>  8 emodnet_wfs biology      https://geo.vliz.be/… mediseh_c… EMOD… "Coral … WFSF… sf    
+#>  9 emodnet_wfs biology      https://geo.vliz.be/… mediseh_c… EMOD… "Coral … WFSF… sf    
+#> 10 emodnet_wfs biology      https://geo.vliz.be/… mediseh_c… EMOD… "Cymodo… WFSF… sf    
 #> # ℹ 1,703 more rows
 #> # ℹ 1 more variable: layer_namespace <chr>
 ```
@@ -255,15 +260,14 @@ To cite emodnet.wfs, please use the output from `citation(package = "emodnet.wfs
 citation(package = "emodnet.wfs")
 #> To cite package 'emodnet.wfs' in publications use:
 #> 
-#>   Krystalli A, Fernández-Bejarano S, Salmon M (????). _emodnet.wfs:
-#>   Access EMODnet Web Feature Service data through R_. doi:10.14284/679
-#>   <https://doi.org/10.14284/679>, R package version 2.0.2.9000.
-#>   Integrated data products created under the European Marine
-#>   Observation Data Network (EMODnet) Biology project
-#>   (EASME/EMFF/2017/1.3.1.2/02/SI2.789013), funded by the by the
-#>   European Union under Regulation (EU) No 508/2014 of the European
-#>   Parliament and of the Council of 15 May 2014 on the European Maritime
-#>   and Fisheries Fund, <https://github.com/EMODnet/emodnet.wfs>.
+#>   Krystalli A, Fernández-Bejarano S, Salmon M (????). _emodnet.wfs: Access
+#>   EMODnet Web Feature Service data through R_. doi:10.14284/679
+#>   <https://doi.org/10.14284/679>, R package version 2.0.2.9000. Integrated
+#>   data products created under the European Marine Observation Data Network
+#>   (EMODnet) Biology project (EASME/EMFF/2017/1.3.1.2/02/SI2.789013), funded by
+#>   the by the European Union under Regulation (EU) No 508/2014 of the European
+#>   Parliament and of the Council of 15 May 2014 on the European Maritime and
+#>   Fisheries Fund, <https://github.com/EMODnet/emodnet.wfs>.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 

--- a/vignettes/emodnet.wfs.Rmd
+++ b/vignettes/emodnet.wfs.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Accessing and mapping EMODnet data"
-output: github_document
+output: rmarkdown::html_vignette
 df_print: "tibble"
 vignette: >
   %\VignetteIndexEntry{API details}

--- a/vignettes/emodnet.wfs.Rmd.orig
+++ b/vignettes/emodnet.wfs.Rmd.orig
@@ -1,7 +1,7 @@
 ---
 title: "Accessing and mapping EMODnet data"
 output: rmarkdown::html_vignette
-df_print: "tibble"
+df_print: "kable"
 vignette: >
   %\VignetteIndexEntry{API details}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/emodnet.wfs.Rmd.orig
+++ b/vignettes/emodnet.wfs.Rmd.orig
@@ -55,12 +55,12 @@ library(mapview)
 library(sf)
 
 services <- emodnet_wfs()
-services$service_name
+class(services)
+names(services)
+services[, c("emodnet_thematic_lot", "service_name")]
 ```
 
-
-
-The column `service_name` shows services available, while  `service_url` has the corresponding base url to perform a WFS request. The Seabed portal should have the data we are looking for. A WFS client can be created by passing the corresponding `service_name` to the function `emodnet_init_wfs_client()`. The layers available to this WFS client are consulted with `emodnet_get_wfs_info()`.
+EMODnet data covers several disciplines organized in 7 thematic lots: bathymetry, biology, chemistry, geology, human activities, physics, seabed habitats. Some thematic lots organize their data in more than one data source or service. The column `service_name` shows services available, while  `service_url` has the corresponding base url to perform a WFS request. The Seabed portal should have the data we are looking for. A WFS client can be created by passing the corresponding `service_name` to the function `emodnet_init_wfs_client()`. The layers available to this WFS client are consulted with `emodnet_get_wfs_info()`.
 
 ```{r}
 seabed_wfs_client <- emodnet_init_wfs_client(service = "seabed_habitats_general_datasets_and_products")


### PR DESCRIPTION
Hi! I recall we talked about adding a new column to `emodnet_wfs()` to specify to what emodnet lot belongs every service (as thematic lots sometimes have more than one WFS endpoint for different services). This column would just be informative and maybe help to filter data from only specific lots. 

Not sure if we agreed on doing this or not, I hope it does not break compatibility. Let me know what you think!